### PR TITLE
Make build behave consistently out-of-gopath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 go:
   # NB: order matters - matrix items that don't specify will use the
   # first value (ditto for `os` below)
-  - 1.9.x
+  - 1.11.x
 
 go_import_path: github.com/bitnami-labs/kube-custodian
 
@@ -31,6 +31,9 @@ before_install: # update to 17.09 to get COPY --from (multistage builds)
       sudo apt-get -y install docker-ce
       sudo apt-get -y install qemu-user-static
     fi
+
+install:
+  - echo dependencies are vendored
 
 script:
   - |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.4-alpine as build
+FROM golang:1.11.4-alpine as build
 
 ARG SRC_REPO=github.com/bitnami-labs/kube-custodian
 ARG SRC_TAG=master


### PR DESCRIPTION
Currently if you checkout this repo in the canonical location in the GOPATH (e.g. by `go get github.com/bitnami-labs/kube-custodian`) and build/test it there (either manually or by running `make something`) it will use dependencies bundled in the `vendor/` dir.

But if you just clone it somewhere else (some people prefer that), then go module support is automatically enabled and running `make` will ignore the vendored directory and download a bunch of files.

The resulting build should be equivalent, but:

1. the user might get hit by github throttling (unless they set the github token in ~/.netrc)
2. we forgot to checkin some changes in `vendor`, in which case the user will see a different behaviour, possibly resulting in confusion about go modules.

I thus suggest we tell `go build` to use `vendor/` no matter what "mode" it think it runs in. They added the `-mod=vendor` flag precisely for this case.
