### PR TITLE
Replace Alpine by minideb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SRC_REPO=github.com/bitnami-labs/kube-custodian
 ARG SRC_TAG=master
 ARG ARCH=amd64
 
-RUN apt-get update
+RUN apt-get upgrade
 
 COPY . /go/src/${SRC_REPO}
 RUN GOARCH=${ARCH} go get ${SRC_REPO}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.11.4-alpine as build
+FROM golang:1.11.4 as build
 
 ARG SRC_REPO=github.com/bitnami-labs/kube-custodian
 ARG SRC_TAG=master
 ARG ARCH=amd64
 
-RUN apk update && apk add git ca-certificates
+RUN apt-get update && apt-get install git ca-certificates
 
 COPY . /go/src/${SRC_REPO}
 RUN GOARCH=${ARCH} go get ${SRC_REPO}
 RUN find /go/bin -name kube-custodian -type f | xargs -I@ install @ /
 
-FROM alpine:3.7
+FROM bitnami/minideb:stretch
 MAINTAINER JuanJo Ciarlante <juanjosec@gmail.com>
 
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG SRC_REPO=github.com/bitnami-labs/kube-custodian
 ARG SRC_TAG=master
 ARG ARCH=amd64
 
-RUN apt-get update && apt-get install git ca-certificates
+RUN apt-get update
 
 COPY . /go/src/${SRC_REPO}
 RUN GOARCH=${ARCH} go get ${SRC_REPO}


### PR DESCRIPTION
- Replace Alpine by minideb
- `git` and `ca-certificates` already installed
```
RUN apt-get update && apt-get install git ca-certificates
 ---> Running in 1259603b97ef
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org/debian-security stretch/updates InRelease [93.6 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [90.3 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]
Get:5 http://security.debian.org/debian-security stretch/updates/main amd64 Packages [499 kB]
Get:6 http://deb.debian.org/debian stretch Release.gpg [2434 B]
Get:7 http://deb.debian.org/debian stretch-updates/main amd64 Packages [27.2 kB]
Get:8 http://deb.debian.org/debian stretch/main amd64 Packages [7082 kB]
Fetched 7912 kB in 1s (5439 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
ca-certificates is already the newest version (20161130+nmu1+deb9u1).
git is already the newest version (1:2.11.0-3+deb9u4).
```